### PR TITLE
fix[POSTCARD]: Preserve whitespace formatting

### DIFF
--- a/apps/web/src/components/Home/feedview/postCard.tsx
+++ b/apps/web/src/components/Home/feedview/postCard.tsx
@@ -130,7 +130,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, isJoined = false }) => {
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <p className="mb-4 text-foreground">{post.content}</p>
+      <p className="mb-4 whitespace-pre-wrap text-foreground">{post.content}</p>
       {post.images && post.images.length > 0 && (
         <div
           className={`mb-4 grid gap-4 ${post.images.length > 1 ? "grid-cols-2" : "grid-cols-1"}`}


### PR DESCRIPTION
Closes #18

<img width="1680" alt="Screenshot 2024-10-12 at 5 57 18 PM" src="https://github.com/user-attachments/assets/e0125d02-1333-42f7-931a-47d5d95a2ce8">
