### PR TITLE
feat[OPTI]: Optimistic updates, mutations for tags

### DIFF
--- a/apps/web/src/components/Tags/MentionTagEditor.tsx
+++ b/apps/web/src/components/Tags/MentionTagEditor.tsx
@@ -54,13 +54,13 @@ export function MentionTagEditor({
   onClose,
   onMentionsUpdate
 }: MentionTagEditorProps) {
-  const [selectedMentions, setSelectedMentions] =
-    useState<UserData[]>(initialMentions);
   const [search, setSearch] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [suggestions, setSuggestions] = useState<UserData[]>([]);
   const { toast } = useToast();
-  const updateMentions = useUpdateMentionsMutation(postId || "");
+  const [selectedMentions, setSelectedMentions] =
+    useState<UserData[]>(initialMentions);
+  const updateMentions = useUpdateMentionsMutation(postId);
 
   const searchUsers = async (query: string) => {
     if (!query.trim()) {
@@ -114,11 +114,17 @@ export function MentionTagEditor({
 
   const handleSave = async () => {
     try {
-      await updateMentions.mutateAsync(selectedMentions.map((m) => m.id));
-      onMentionsUpdate?.(selectedMentions);
+      onMentionsUpdate(selectedMentions);
       onClose();
+
+      await updateMentions.mutateAsync(selectedMentions.map((m) => m.id));
+      // biome-ignore lint/correctness/noUnusedVariables: ignore
     } catch (error) {
-      console.error("Failed to update mentions:", error);
+      toast({
+        title: "Error",
+        description: "Failed to update mentions. Please try again.",
+        variant: "destructive"
+      });
     }
   };
 

--- a/apps/web/src/components/Tags/mutations/cache-utils.ts
+++ b/apps/web/src/components/Tags/mutations/cache-utils.ts
@@ -1,0 +1,29 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { PostData } from "@zephyr/db";
+
+export function updatePostInCaches(
+  queryClient: QueryClient,
+  postId: string,
+  updater: (post: PostData) => PostData
+) {
+  queryClient.setQueryData(["post", postId], updater);
+
+  // biome-ignore lint/complexity/noForEach: ignore
+  ["post-feed", "posts:for-you", "posts:following"].forEach((key) => {
+    queryClient.setQueryData(
+      [key],
+      (oldData: { pages: { posts: PostData[] }[] } | undefined) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page) => ({
+            ...page,
+            posts: page.posts.map((post) =>
+              post.id === postId ? updater(post) : post
+            )
+          }))
+        };
+      }
+    );
+  });
+}

--- a/apps/web/src/components/Tags/mutations/tag-mention-mutation.ts
+++ b/apps/web/src/components/Tags/mutations/tag-mention-mutation.ts
@@ -1,0 +1,129 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { PostData, TagWithCount, UserData } from "@zephyr/db";
+import { updatePostInCaches } from "./cache-utils";
+
+interface TagsMutationContext {
+  previousPost: PostData | undefined;
+}
+
+interface MentionsMutationContext {
+  previousPost: PostData | undefined;
+}
+
+export function useUpdateTagsMutation(postId?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<PostData, Error, string[], TagsMutationContext>({
+    mutationFn: async (tags) => {
+      const response = await fetch(`/api/posts/${postId}/tags`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ tags })
+      });
+      if (!response.ok) {
+        throw new Error("Failed to update tags");
+      }
+      return response.json();
+    },
+    onMutate: async (newTags) => {
+      if (!postId) {
+        return { previousPost: undefined };
+      }
+
+      await queryClient.cancelQueries({ queryKey: ["post", postId] });
+
+      const previousPost = queryClient.getQueryData<PostData>(["post", postId]);
+
+      const optimisticTags: TagWithCount[] = newTags.map((name) => ({
+        id: name,
+        name,
+        _count: { posts: 1 },
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }));
+
+      updatePostInCaches(queryClient, postId, (post) => ({
+        ...post,
+        tags: optimisticTags
+      }));
+
+      return { previousPost };
+    },
+    onError: (_, __, context) => {
+      if (postId && context?.previousPost) {
+        updatePostInCaches(
+          queryClient,
+          postId,
+          () => context.previousPost as PostData
+        );
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["post", postId] });
+      queryClient.invalidateQueries({ queryKey: ["post-feed"] });
+      queryClient.invalidateQueries({ queryKey: ["popularTags"] });
+    }
+  });
+}
+
+export function useUpdateMentionsMutation(postId?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<PostData, Error, string[], MentionsMutationContext>({
+    mutationFn: async (userIds) => {
+      const response = await fetch(`/api/posts/${postId}/mentions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ userIds })
+      });
+      if (!response.ok) {
+        throw new Error("Failed to update mentions");
+      }
+      return response.json();
+    },
+    onMutate: async (newUserIds) => {
+      if (!postId) {
+        return { previousPost: undefined };
+      }
+
+      await queryClient.cancelQueries({ queryKey: ["post", postId] });
+
+      const previousPost = queryClient.getQueryData<PostData>(["post", postId]);
+
+      const users = newUserIds
+        .map((id) => queryClient.getQueryData<UserData>(["user", id]))
+        .filter((u): u is UserData => !!u);
+
+      updatePostInCaches(queryClient, postId, (post) => ({
+        ...post,
+        mentions: users.map((user) => ({
+          id: `${postId}-${user.id}`,
+          postId,
+          userId: user.id,
+          user,
+          createdAt: new Date()
+        }))
+      }));
+
+      return { previousPost };
+    },
+    onError: (_, __, context) => {
+      if (postId && context?.previousPost) {
+        updatePostInCaches(
+          queryClient,
+          postId,
+          () => context.previousPost as PostData
+        );
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["post", postId] });
+      queryClient.invalidateQueries({ queryKey: ["post-feed"] });
+      queryClient.invalidateQueries({ queryKey: ["mentions"] });
+    }
+  });
+}

--- a/apps/web/src/posts/editor/mutations.ts
+++ b/apps/web/src/posts/editor/mutations.ts
@@ -26,7 +26,7 @@ export function useSubmitPostMutation() {
         content: input.content,
         mediaIds: input.mediaIds || [],
         tags: input.tags || [],
-        mentions: Array.isArray(input.mentions) 
+        mentions: Array.isArray(input.mentions)
           ? input.mentions.filter(Boolean)
           : []
       };


### PR DESCRIPTION
This implementation caused : Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.  So soon well be migrating to state management "Zustand" Currently pushing for testing purpose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced state management for posts, tags, and mentions across various components
  - Improved reactivity and local state handling in feed and post views

- **Performance Improvements**
  - Optimized component rendering with memoized callbacks
  - Added loading state management for better user experience

- **Bug Fixes**
  - Improved handling of post updates and synchronization
  - Enhanced error handling for tag and mention mutations

- **User Experience**
  - Added more responsive interactions in post editing dialogs
  - Refined loading and update states in tag and mention components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->